### PR TITLE
fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export function apply(ctx: Context, cfg: Config) {
       const excludes = cfg.excludeUsers.map(({ uid }) => uid)
       excludes.push(session.uid, session.sid)
 
-      let list = memberList.filter(v => !excludes.includes(`${session.platform}:${v.user.id}`) && !v.user.isBot)
+      let list = memberList.filter(v => v.user && !excludes.includes(`${session.platform}:${v.user.id}`) && !v.user.isBot)
 
       if (cfg.onlyActiveUser) {
         let activeList: string[] = []


### PR DESCRIPTION
command waifu 
                        TypeError: Cannot read properties of undefined (reading 'id')
                            at /koishi/node_modules/koishi-plugin-waifu/lib/index.js:66:92
                            at Array.filter (<anonymous>)
                            at Command.<anonymous> (/koishi/node_modules/koishi-plugin-waifu/lib/index.js:66:31)
                            at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
                            at async Array.<anonymous> (/koishi/node_modules/@koishijs/core/lib/index.cjs:1137:14)
                            at async Command.execute (/koishi/node_modules/@koishijs/core/lib/index.cjs:1151:22)
                            at async /koishi/node_modules/@koishijs/core/lib/index.cjs:2170:22
                            at async Proxy.withScope (/koishi/node_modules/@koishijs/core/lib/index.cjs:2073:22)
                            at async next (/koishi/node_modules/@koishijs/core/lib/index.cjs:876:16)
                            at async next (/koishi/node_modules/@koishijs/core/lib/index.cjs:876:16)