### PR TITLE
修复了在新版satori适配器下获取不到群成员信息的问题、戳一戳消息被视为群成员的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export function apply(ctx: Context, cfg: Config) {
 
   ctx.guild().on('message-created', async (session) => {
     if (isNullable(session.userId) || session.userId == '0') return
-    const member: Universal.GuildMember = { user: session.event.user,nick: session.event.member.nick }
+    const member: Universal.GuildMember = { user: session.event.user, ...session.event.member }
     await ctx.cache.set(`waifu_members_${session.gid}`, session.userId, member, 4 * Time.day)
     await ctx.cache.set(`waifu_members_active_${session.gid}`, session.userId, '', cfg.activeDays * Time.day)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export function apply(ctx: Context, cfg: Config) {
   })
 
   ctx.on('guild-member-removed', (session) => {
-    if (isNullable(session.userId) || session.userId == "0") return
+    if (isNullable(session.userId) || session.userId == '0') return
     ctx.cache.delete(`waifu_members_${session.gid}`, session.userId)
     ctx.cache.delete(`waifu_members_active_${session.gid}`, session.userId)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export function apply(ctx: Context, cfg: Config) {
   // sid: platform:selfId
 
   ctx.guild().on('message-created', async (session) => {
-    if (isNullable(session.userId) || session.userId == "0") return
+    if (isNullable(session.userId) || session.userId == '0') return
     const member: Universal.GuildMember = { user: session.event.user,nick: session.event.member.nick }
     await ctx.cache.set(`waifu_members_${session.gid}`, session.userId, member, 4 * Time.day)
     await ctx.cache.set(`waifu_members_active_${session.gid}`, session.userId, '', cfg.activeDays * Time.day)


### PR DESCRIPTION
可能由于接口改变，群成员信息不能正确写入member表中，进行了修改。
在adapter-satori+chronocat_v0.2.15下测试